### PR TITLE
build: use the LTS version of Node.js as a base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS node
+FROM node:20.11-alpine AS node
 
 FROM node AS node-with-gyp
 RUN apk add g++ make python3


### PR DESCRIPTION
The Docker image has been updated to use Node version 20.11-alpine instead of the previous version 16-alpine. This change will ensure our project stays up to date with the latest improvements and security patches in Node.js.